### PR TITLE
Let EQUALP defer to CL:EQUALP by default

### DIFF
--- a/src/equality.lisp
+++ b/src/equality.lisp
@@ -93,7 +93,7 @@
   "Default equality comparison method. Returns true if objects A and B
    are the same object, compared using CL:EQ."
 
-  (cl:eq a b))
+  (cl:equalp a b))
 
 
 ;;;; N-Argument Functions


### PR DESCRIPTION
Hi,

I understand that there is no portable way to recurse into structures with the generic EQUALP function, so maybe this is the reason for not calling CL:EQUALP in the default method. 

On the other hand, I would expect a package that uses GENERIC-CL instead of CL to still work as before, and as such, for compatibility reasons, I think it might be preferable to call CL:EQUALP instead of CL:EQ, which can break existing code (when calling it on structures or hash-tables).

Thank you